### PR TITLE
Prototype approval test for GetRoundStateDelta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ index.html
 
 # test summary
 testresults.json
+
+# Received approval test files
+*.received.*

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -158,7 +158,7 @@ func TestGetRoundStateDelta(t *testing.T) {
 }
 
 type AssertableHTTPResponse struct {
-	Status     string      `json:"status""`
+	Status     string      `json:"status"`
 	StatusCode int         `json:"statusCode"`
 	Headers    http.Header `json:"headers"`
 	Body       interface{} `json:"body"`

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	approvals "github.com/approvals/go-approval-tests"
+	"github.com/approvals/go-approval-tests/reporters"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -153,6 +155,46 @@ func TestGetRoundStateDelta(t *testing.T) {
 	require.Equal(t, poolDeltaResponseGolden.TxLeases, actualResponse.TxLeases)
 	require.Equal(t, poolDeltaResponseGolden.TxIds, actualResponse.TxIds)
 	require.Equal(t, poolDeltaResponseGolden.Totals, actualResponse.Totals)
+}
+
+type AssertableHTTPResponse struct {
+	Status     string      `json:"status""`
+	StatusCode int         `json:"statusCode"`
+	Headers    http.Header `json:"headers"`
+	Body       interface{} `json:"body"`
+}
+
+func TestGetRoundStateDeltaApproval(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	handler, c, rec, _, _, releasefunc := setupTestForMethodGet(t)
+	defer releasefunc()
+	insertRounds(a, handler, 3)
+
+	err := handler.GetRoundStateDelta(c, 2)
+	require.NoError(t, err)
+
+	actualResponse := model.RoundStateDelta{}
+	err = protocol.DecodeJSON(rec.Body.Bytes(), &actualResponse)
+
+	// Blot out non-deterministic PrevTimestamp
+	require.NotZero(t, actualResponse.PrevTimestamp)
+	z := uint64(0)
+	actualResponse.PrevTimestamp = &z
+
+	res := rec.Result()
+	resp := AssertableHTTPResponse{
+		res.Status,
+		res.StatusCode,
+		res.Header,
+		actualResponse,
+	}
+
+	approvals.UseFolder("testdata")
+	approvals.UseReporter(reporters.NewRealDiffReporter())
+	approvals.VerifyJSONBytes(t, protocol.EncodeJSON(resp))
 }
 
 func TestSyncRound(t *testing.T) {

--- a/daemon/algod/api/server/v2/test/testdata/handlers_test.TestGetRoundStateDeltaApproval.approved.json
+++ b/daemon/algod/api/server/v2/test/testdata/handlers_test.TestGetRoundStateDeltaApproval.approved.json
@@ -1,0 +1,45 @@
+{
+  "body": {
+    "accts": {
+      "accounts": [
+        {
+          "account-data": {
+            "address": "7777777777777777777777777777777777777777777777777774MSJUVU",
+            "amount": 50000000000,
+            "amount-without-pending-rewards": 50000000000,
+            "min-balance": 100000,
+            "pending-rewards": 0,
+            "rewards": 0,
+            "round": 2,
+            "status": "Not Participating",
+            "total-apps-opted-in": 0,
+            "total-assets-opted-in": 0,
+            "total-created-apps": 0,
+            "total-created-assets": 0
+          },
+          "address": "7777777777777777777777777777777777777777777777777774MSJUVU"
+        }
+      ]
+    },
+    "totals": {
+      "not-participating": 100000000000,
+      "offline": 0,
+      "online": 658511,
+      "rewards-level": 0
+    },
+    "tx-ids": [
+      {
+        "intra": 0,
+        "lastValid": 0,
+        "txId": "Z7ATVET4TI3UG32H2PYJQPREPYOQHAH376E25M3KB57OEW66YMPA"
+      }
+    ]
+  },
+  "headers": {
+    "Content-Type": [
+      "application/json; charset=UTF-8"
+    ]
+  },
+  "status": "200 OK",
+  "statusCode": 200
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/algorand/msgp v1.1.53
 	github.com/algorand/oapi-codegen v1.12.0-algorand.0
 	github.com/algorand/websocket v1.4.5
+	github.com/approvals/go-approval-tests v0.0.0-20220530063708-32d5677069bd
 	github.com/aws/aws-sdk-go v1.16.5
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/algorand/websocket v1.4.5 h1:Cs6UTaCReAl02evYxmN8k57cNHmBILRcspfSxYg4
 github.com/algorand/websocket v1.4.5/go.mod h1:79n6FSZY08yQagHzE/YWZqTPBYfY5wc3IS+UTZe1W5c=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
+github.com/approvals/go-approval-tests v0.0.0-20220530063708-32d5677069bd h1:8j7sBEy0h6+Bvr0AeKHIHCsmzCzWGXAQweA7k+uiRYk=
+github.com/approvals/go-approval-tests v0.0.0-20220530063708-32d5677069bd/go.mod h1:PJOqSY8IofNv3heAD6k8E7EfFS6okiSS9bSAasaAUME=
 github.com/aws/aws-sdk-go v1.16.5 h1:NVxzZXIuwX828VcJrpNxxWjur1tlOBISdMdDdHIKHcc=
 github.com/aws/aws-sdk-go v1.16.5/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=


### PR DESCRIPTION
Adds a rough example demonstrating how we can write a more robust version of `TestGetRoundStateDelta` using https://github.com/approvals/go-approval-tests.

The approach is to use a human readable (JSON) representation of the HTTP response to test equality rather than relying on a hand-built object in tests.  The approval test approach confirms _all_ properties (including HTTP headers) are exercised.

Provided we agree the approach is worth taking in, I see a few points worth discussing (probably live):
* We can write the test without the library.  I chose to use the library because it feels like a way to standardize similar tests we've written in other places.   Examples:
  * https://github.com/algorand/go-algorand/blob/1cf857f7eab3288bdd7a84b041d7d767a62a25cb/gen/generate_test.go#L130
  * https://github.com/algorand/indexer/blob/ef6ecf14e870d8e3c9c3e513300eafe7670e6019/api/handlers_test.go#L410 
  * https://github.com/algorand/indexer/tree/develop/api#fixtures-test
* I can imagine several ways to enrich test structure that will reduce writing similar tests.  I can work on adding enrichments after a quick touch base.