### PR TITLE
Reuse basics to model converters

### DIFF
--- a/daemon/algod/api/server/v2/account.go
+++ b/daemon/algod/api/server/v2/account.go
@@ -86,15 +86,7 @@ func AccountDataToAccount(
 
 	appsLocalState := make([]model.ApplicationLocalState, 0, len(record.AppLocalStates))
 	for appIdx, state := range record.AppLocalStates {
-		localState := convertTKVToGenerated(&state.KeyValue)
-		appsLocalState = append(appsLocalState, model.ApplicationLocalState{
-			Id:       uint64(appIdx),
-			KeyValue: localState,
-			Schema: model.ApplicationStateSchema{
-				NumByteSlice: state.Schema.NumByteSlice,
-				NumUint:      state.Schema.NumUint,
-			},
-		})
+		appsLocalState = append(appsLocalState, AppLocalState(state, appIdx))
 	}
 	sort.Slice(appsLocalState, func(i, j int) bool {
 		return appsLocalState[i].Id < appsLocalState[j].Id
@@ -445,6 +437,19 @@ func AppParamsToApplication(creator string, appIdx basics.AppIndex, appParams *b
 		},
 	}
 	return app
+}
+
+// AppLocalState constructs model.ApplicationLocalState from basics.AppLocalState.
+func AppLocalState(state basics.AppLocalState, appIdx basics.AppIndex) model.ApplicationLocalState {
+	localState := convertTKVToGenerated(&state.KeyValue)
+	return model.ApplicationLocalState{
+		Id:       uint64(appIdx),
+		KeyValue: localState,
+		Schema: model.ApplicationStateSchema{
+			NumByteSlice: state.Schema.NumByteSlice,
+			NumUint:      state.Schema.NumUint,
+		},
+	}
 }
 
 // AssetParamsToAsset converts basics.AssetParams to model.Asset

--- a/daemon/algod/api/server/v2/account.go
+++ b/daemon/algod/api/server/v2/account.go
@@ -28,6 +28,14 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 )
 
+func AssetHolding(ah basics.AssetHolding, ai basics.AssetIndex) model.AssetHolding {
+	return model.AssetHolding{
+		Amount:   ah.Amount,
+		AssetID:  uint64(ai),
+		IsFrozen: ah.Frozen,
+	}
+}
+
 // AccountDataToAccount converts basics.AccountData to v2.model.Account
 func AccountDataToAccount(
 	address string, record *basics.AccountData,
@@ -39,11 +47,7 @@ func AccountDataToAccount(
 	for curid, holding := range record.Assets {
 		// Empty is ok, asset may have been deleted, so we can no
 		// longer fetch the creator
-		holding := model.AssetHolding{
-			Amount:   holding.Amount,
-			AssetID:  uint64(curid),
-			IsFrozen: holding.Frozen,
-		}
+		holding := AssetHolding(holding, curid)
 
 		assets = append(assets, holding)
 	}
@@ -439,7 +443,6 @@ func AppParamsToApplication(creator string, appIdx basics.AppIndex, appParams *b
 	return app
 }
 
-// AppLocalState constructs model.ApplicationLocalState from basics.AppLocalState.
 func AppLocalState(state basics.AppLocalState, appIdx basics.AppIndex) model.ApplicationLocalState {
 	localState := convertTKVToGenerated(&state.KeyValue)
 	return model.ApplicationLocalState{

--- a/daemon/algod/api/server/v2/delta.go
+++ b/daemon/algod/api/server/v2/delta.go
@@ -30,15 +30,8 @@ import (
 func convertAppResourceRecordToGenerated(app ledgercore.AppResourceRecord) model.AppResourceRecord {
 	var appLocalState *model.ApplicationLocalState = nil
 	if app.State.LocalState != nil {
-		localState := convertTKVToGenerated(&app.State.LocalState.KeyValue)
-		appLocalState = &model.ApplicationLocalState{
-			Id:       uint64(app.Aidx),
-			KeyValue: localState,
-			Schema: model.ApplicationStateSchema{
-				NumByteSlice: app.State.LocalState.Schema.NumByteSlice,
-				NumUint:      app.State.LocalState.Schema.NumUint,
-			},
-		}
+		s := AppLocalState(*app.State.LocalState, app.Aidx)
+		appLocalState = &s
 	}
 	var appParams *model.ApplicationParams = nil
 	if app.Params.Params != nil {

--- a/daemon/algod/api/server/v2/delta.go
+++ b/daemon/algod/api/server/v2/delta.go
@@ -17,7 +17,6 @@
 package v2
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -43,22 +42,8 @@ func convertAppResourceRecordToGenerated(app ledgercore.AppResourceRecord) model
 	}
 	var appParams *model.ApplicationParams = nil
 	if app.Params.Params != nil {
-		globalState := convertTKVToGenerated(&app.Params.Params.GlobalState)
-		appParams = &model.ApplicationParams{
-			ApprovalProgram:   app.Params.Params.ApprovalProgram,
-			ClearStateProgram: app.Params.Params.ClearStateProgram,
-			Creator:           app.Addr.String(),
-			ExtraProgramPages: numOrNil(uint64(app.Params.Params.ExtraProgramPages)),
-			GlobalState:       globalState,
-			GlobalStateSchema: &model.ApplicationStateSchema{
-				NumByteSlice: app.Params.Params.GlobalStateSchema.NumByteSlice,
-				NumUint:      app.Params.Params.GlobalStateSchema.NumUint,
-			},
-			LocalStateSchema: &model.ApplicationStateSchema{
-				NumByteSlice: app.Params.Params.LocalStateSchema.NumByteSlice,
-				NumUint:      app.Params.Params.LocalStateSchema.NumUint,
-			},
-		}
+		p := AppParamsToApplication(app.Addr.String(), app.Aidx, app.Params.Params).Params
+		appParams = &p
 	}
 	return model.AppResourceRecord{
 		Address:              app.Addr.String(),
@@ -82,23 +67,8 @@ func convertAssetResourceRecordToGenerated(asset ledgercore.AssetResourceRecord)
 	}
 	var assetParams *model.AssetParams = nil
 	if asset.Params.Params != nil {
-		assetParams = &model.AssetParams{
-			Clawback:      strOrNil(asset.Params.Params.Clawback.String()),
-			Creator:       asset.Addr.String(),
-			Decimals:      uint64(asset.Params.Params.Decimals),
-			DefaultFrozen: &asset.Params.Params.DefaultFrozen,
-			Freeze:        strOrNil(asset.Params.Params.Freeze.String()),
-			Manager:       strOrNil(asset.Params.Params.Manager.String()),
-			MetadataHash:  byteOrNil(asset.Params.Params.MetadataHash[:]),
-			Name:          strOrNil(asset.Params.Params.AssetName),
-			NameB64:       byteOrNil([]byte(base64.StdEncoding.EncodeToString([]byte(asset.Params.Params.AssetName)))),
-			Reserve:       strOrNil(asset.Params.Params.Reserve.String()),
-			Total:         asset.Params.Params.Total,
-			UnitName:      strOrNil(asset.Params.Params.UnitName),
-			UnitNameB64:   byteOrNil([]byte(base64.StdEncoding.EncodeToString([]byte(asset.Params.Params.UnitName)))),
-			Url:           strOrNil(asset.Params.Params.URL),
-			UrlB64:        byteOrNil([]byte(base64.StdEncoding.EncodeToString([]byte(asset.Params.Params.URL)))),
-		}
+		a := AssetParamsToAsset(asset.Addr.String(), asset.Aidx, asset.Params.Params)
+		assetParams = &a.Params
 	}
 	return model.AssetResourceRecord{
 		Address:             asset.Addr.String(),

--- a/daemon/algod/api/server/v2/delta.go
+++ b/daemon/algod/api/server/v2/delta.go
@@ -52,11 +52,8 @@ func convertAppResourceRecordToGenerated(app ledgercore.AppResourceRecord) model
 func convertAssetResourceRecordToGenerated(asset ledgercore.AssetResourceRecord) model.AssetResourceRecord {
 	var assetHolding *model.AssetHolding = nil
 	if asset.Holding.Holding != nil {
-		assetHolding = &model.AssetHolding{
-			Amount:   asset.Holding.Holding.Amount,
-			AssetID:  uint64(asset.Aidx),
-			IsFrozen: asset.Holding.Holding.Frozen,
-		}
+		a := AssetHolding(*asset.Holding.Holding, asset.Aidx)
+		assetHolding = &a
 	}
 	var assetParams *model.AssetParams = nil
 	if asset.Params.Params != nil {


### PR DESCRIPTION
Extends https://github.com/algorand/go-algorand/pull/4658 to promote reuse of previously defined converters from `basics`-to-`model`.  The intent is to help enforce the idea that there's only 1 correct way to specify conversion.

The PR _only_ exposes conversions for structs initialized in > 1 place.  The PR does _not_ expose converters for `model`s added in https://github.com/algorand/go-algorand/pull/4658.